### PR TITLE
Fix: Loosen url check to apply to different login providers

### DIFF
--- a/docs/chrome-web-store-listing.md
+++ b/docs/chrome-web-store-listing.md
@@ -26,8 +26,9 @@ It applies local CSS rules on selected authentication pages to hide visible Finn
 
 ### Supported URLs
 
-- `https://userapi2.danskebank.com/prod/external/ftn/idp-oidc/connect/sign-in*`
-- `https://tunnistautuminen.suomi.fi/idp/profile/SAML2/Redirect/SSO*`
+- `https://userapi2.danskebank.com/prod/external*`
+- `https://tunnistautuminen.suomi.fi/idp/profile*`
+- `https://online.s-pankki.fi/ftn/initSession*`
 
 ## Privacy practices (store form guidance)
 

--- a/manifest.json
+++ b/manifest.json
@@ -20,8 +20,8 @@
   "content_scripts": [
     {
       "matches": [
-        "https://userapi2.danskebank.com/prod/external/ftn/idp-oidc/connect/sign-in*",
-        "https://tunnistautuminen.suomi.fi/idp/profile/SAML2/Redirect/SSO*",
+        "https://userapi2.danskebank.com/prod/external*",
+        "https://tunnistautuminen.suomi.fi/idp/profile*",
         "https://online.s-pankki.fi/ftn/initSession*"
       ],
       "css": ["hide.css"],


### PR DESCRIPTION
Apparently there's some difference in the provider implementation of FI strong authentication logins, this should make the matching a bit looser while still keeping it only on the authentication pages